### PR TITLE
serialize not string map key

### DIFF
--- a/src/de/access/map.rs
+++ b/src/de/access/map.rs
@@ -79,14 +79,14 @@ where
     T: 'a + Tokenizer<'de>,
     &'a mut Self: de::Deserializer<'de>,
 {
-    pub fn double_quote<V, F>(
+    pub fn double_quote<V, Fn>(
         &mut self,
         visitor: V,
-        f: F,
+        f: Fn,
     ) -> Result<V::Value, <&'a mut Self as de::Deserializer<'de>>::Error>
     where
         V: de::Visitor<'de>,
-        F: FnOnce(&mut Self, V) -> Result<V::Value, <&'a mut Self as de::Deserializer<'de>>::Error>,
+        Fn: FnOnce(&mut Self, V) -> Result<V::Value, <&'a mut Self as de::Deserializer<'de>>::Error>,
         <&'a mut Self as de::Deserializer<'de>>::Error: From<crate::Error>,
     {
         match self.deserializer.tokenizer.eat()?.ok_or(SyntaxError::EofWhileParsingObjectKey.into())? {

--- a/src/ser/access/map.rs
+++ b/src/ser/access/map.rs
@@ -47,7 +47,7 @@ where
         T: ser::Serialize,
     {
         self.serializer.formatter.write_object_value_start(&mut self.serializer.write, self.index, self.len)?;
-        value.serialize(&mut *self.serializer)?;
+        value.serialize(&mut MapKeySerializer::new(self.serializer))?;
         self.serializer.formatter.write_object_value_end(&mut self.serializer.write, self.index, self.len)?;
         Ok(self.index += 1)
     }
@@ -76,4 +76,27 @@ where
     fn end(self) -> Result<Self::Ok, Self::Error> {
         <Self as ser::SerializeMap>::end(self)
     }
+}
+
+pub struct MapKeySerializer<'a, W, F>
+where
+    F: JsoncFormatter,
+{
+    pub serializer: &'a mut JsoncSerializer<W, F>,
+}
+
+impl<'a, W, F> MapKeySerializer<'a, W, F>
+where
+    F: JsoncFormatter,
+{
+    pub fn new(serializer: &'a mut JsoncSerializer<W, F>) -> Self {
+        Self { serializer }
+    }
+}
+
+impl<'a, W, F> ser::Serializer for &'a mut MapKeySerializer<'a, W, F>
+where
+    W: std::io::Write,
+    F: JsoncFormatter,
+{
 }

--- a/src/ser/access/map.rs
+++ b/src/ser/access/map.rs
@@ -1,6 +1,6 @@
 use std::fmt::Formatter;
 
-use serde::ser;
+use serde::{ser, Serialize};
 
 use crate::ser::formatter::JsoncFormatter;
 
@@ -126,7 +126,7 @@ where
     type SerializeStructVariant = ser::Impossible<(), Self::Error>;
 
     fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
-        self.double_quote(|s| s.serializer.formatter.write_bool(&mut s.serializer.write, v))
+        self.double_quote(|s| v.serialize(&mut *s.serializer))
     }
 
     fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {

--- a/src/ser/access/map.rs
+++ b/src/ser/access/map.rs
@@ -1,3 +1,5 @@
+use std::fmt::Formatter;
+
 use serde::ser;
 
 use crate::ser::formatter::JsoncFormatter;
@@ -37,7 +39,7 @@ where
         T: ser::Serialize,
     {
         self.serializer.formatter.write_object_key_start(&mut self.serializer.write, self.index, self.len)?;
-        key.serialize(&mut *self.serializer)?;
+        key.serialize(&mut MapKeySerializer::new(self.serializer))?;
         self.serializer.formatter.write_object_key_end(&mut self.serializer.write, self.index, self.len)?;
         Ok(())
     }
@@ -47,7 +49,7 @@ where
         T: ser::Serialize,
     {
         self.serializer.formatter.write_object_value_start(&mut self.serializer.write, self.index, self.len)?;
-        value.serialize(&mut MapKeySerializer::new(self.serializer))?;
+        value.serialize(&mut *self.serializer)?;
         self.serializer.formatter.write_object_value_end(&mut self.serializer.write, self.index, self.len)?;
         Ok(self.index += 1)
     }
@@ -88,9 +90,23 @@ where
 impl<'a, W, F> MapKeySerializer<'a, W, F>
 where
     F: JsoncFormatter,
+    W: std::io::Write,
 {
     pub fn new(serializer: &'a mut JsoncSerializer<W, F>) -> Self {
         Self { serializer }
+    }
+
+    pub fn double_quote<Fn>(&mut self, f: Fn) -> Result<<&'a mut Self as ser::Serializer>::Ok, crate::Error>
+    where
+        Fn: FnOnce(
+            &mut Self,
+        ) -> Result<<&'a mut Self as ser::Serializer>::Ok, <&'a mut Self as ser::Serializer>::Error>,
+        <&'a mut Self as ser::Serializer>::Error: From<crate::Error>,
+    {
+        self.serializer.write.write_all(b"\"")?;
+        f(self)?;
+        self.serializer.write.write_all(b"\"")?;
+        Ok(())
     }
 }
 
@@ -99,4 +115,157 @@ where
     W: std::io::Write,
     F: JsoncFormatter,
 {
+    type Ok = ();
+    type Error = crate::Error;
+    type SerializeSeq = ser::Impossible<(), Self::Error>;
+    type SerializeTuple = ser::Impossible<(), Self::Error>;
+    type SerializeTupleStruct = ser::Impossible<(), Self::Error>;
+    type SerializeTupleVariant = ser::Impossible<(), Self::Error>;
+    type SerializeMap = ser::Impossible<(), Self::Error>;
+    type SerializeStruct = ser::Impossible<(), Self::Error>;
+    type SerializeStructVariant = ser::Impossible<(), Self::Error>;
+
+    fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
+        self.double_quote(|s| s.serializer.formatter.write_bool(&mut s.serializer.write, v))
+    }
+
+    fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ser::Serialize,
+    {
+        todo!()
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_unit_variant(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_newtype_struct<T: ?Sized>(self, name: &'static str, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ser::Serialize,
+    {
+        todo!()
+    }
+
+    fn serialize_newtype_variant<T: ?Sized>(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ser::Serialize,
+    {
+        todo!()
+    }
+
+    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_tuple_struct(self, name: &'static str, len: usize) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_struct(self, name: &'static str, len: usize) -> Result<Self::SerializeStruct, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_struct_variant(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        todo!()
+    }
 }

--- a/src/ser/access/map.rs
+++ b/src/ser/access/map.rs
@@ -1,8 +1,6 @@
-use std::fmt::Formatter;
-
 use serde::{ser, Serialize};
 
-use crate::ser::formatter::JsoncFormatter;
+use crate::{error::SemanticError, ser::formatter::JsoncFormatter};
 
 use super::jsonc::JsoncSerializer;
 
@@ -184,90 +182,94 @@ where
     }
 
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        Err(SemanticError::AnyMapKey)?
     }
 
     fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
     where
         T: ser::Serialize,
     {
-        todo!()
+        value.serialize(self)
     }
 
     fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        Err(SemanticError::AnyMapKey)?
     }
 
-    fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Self::Error> {
-        todo!()
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        Err(SemanticError::AnyMapKey)?
     }
 
     fn serialize_unit_variant(
         self,
-        name: &'static str,
-        variant_index: u32,
-        variant: &'static str,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
     ) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        Err(SemanticError::AnyMapKey)?
     }
 
-    fn serialize_newtype_struct<T: ?Sized>(self, name: &'static str, value: &T) -> Result<Self::Ok, Self::Error>
+    fn serialize_newtype_struct<T: ?Sized>(self, _name: &'static str, _value: &T) -> Result<Self::Ok, Self::Error>
     where
         T: ser::Serialize,
     {
-        todo!()
+        Err(SemanticError::AnyMapKey)?
     }
 
     fn serialize_newtype_variant<T: ?Sized>(
         self,
-        name: &'static str,
-        variant_index: u32,
-        variant: &'static str,
-        value: &T,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
         T: ser::Serialize,
     {
-        todo!()
+        Err(SemanticError::AnyMapKey)?
     }
 
-    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
-        todo!()
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Err(SemanticError::AnyMapKey)?
     }
 
-    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
-        todo!()
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Err(SemanticError::AnyMapKey)?
     }
 
-    fn serialize_tuple_struct(self, name: &'static str, len: usize) -> Result<Self::SerializeTupleStruct, Self::Error> {
-        todo!()
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Err(SemanticError::AnyMapKey)?
     }
 
     fn serialize_tuple_variant(
         self,
-        name: &'static str,
-        variant_index: u32,
-        variant: &'static str,
-        len: usize,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
-        todo!()
+        Err(SemanticError::AnyMapKey)?
     }
 
-    fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
-        todo!()
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Err(SemanticError::AnyMapKey)?
     }
 
-    fn serialize_struct(self, name: &'static str, len: usize) -> Result<Self::SerializeStruct, Self::Error> {
-        todo!()
+    fn serialize_struct(self, _name: &'static str, _len: usize) -> Result<Self::SerializeStruct, Self::Error> {
+        Err(SemanticError::AnyMapKey)?
     }
 
     fn serialize_struct_variant(
         self,
-        name: &'static str,
-        variant_index: u32,
-        variant: &'static str,
-        len: usize,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
-        todo!()
+        Err(SemanticError::AnyMapKey)?
     }
 }

--- a/src/ser/access/map.rs
+++ b/src/ser/access/map.rs
@@ -130,55 +130,57 @@ where
     }
 
     fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        self.double_quote(|s| v.serialize(&mut *s.serializer))
     }
 
     fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        self.double_quote(|s| v.serialize(&mut *s.serializer))
     }
 
     fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        self.double_quote(|s| v.serialize(&mut *s.serializer))
     }
 
     fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        self.double_quote(|s| v.serialize(&mut *s.serializer))
     }
 
     fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        self.double_quote(|s| v.serialize(&mut *s.serializer))
     }
 
     fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        self.double_quote(|s| v.serialize(&mut *s.serializer))
     }
 
     fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        self.double_quote(|s| v.serialize(&mut *s.serializer))
     }
 
     fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        self.double_quote(|s| v.serialize(&mut *s.serializer))
     }
 
     fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        // TODO check inf
+        self.double_quote(|s| v.serialize(&mut *s.serializer))
     }
 
     fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        // TODO check inf
+        self.double_quote(|s| v.serialize(&mut *s.serializer))
     }
 
     fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        self.double_quote(|s| v.serialize(&mut *s.serializer))
     }
 
     fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        v.serialize(&mut *self.serializer)
     }
 
     fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
-        todo!()
+        v.serialize(&mut *self.serializer)
     }
 
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {

--- a/src/ser/access/map.rs
+++ b/src/ser/access/map.rs
@@ -193,7 +193,7 @@ where
     }
 
     fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
-        Err(SemanticError::AnyMapKey)?
+        self.double_quote(|s| ().serialize(&mut *s.serializer))
     }
 
     fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {

--- a/tests/integration/spec.rs
+++ b/tests/integration/spec.rs
@@ -66,6 +66,16 @@ fn test_not_string_map_key() {
     for (tl, jl) in target_number_key.lines().zip(jsonc.lines()) {
         assert_eq!(tl.trim(), jl.trim());
     }
+
+    let target_unit_key = r#"{
+        "null": false,
+    }"#;
+    let map: HashMap<(), bool> = from_str(target_unit_key).unwrap();
+    assert_eq!(map, HashMap::from([((), false)]));
+    let jsonc = to_string_pretty(&map, Default::default()).unwrap();
+    for (tl, jl) in target_unit_key.lines().zip(jsonc.lines()) {
+        assert_eq!(tl.trim(), jl.trim());
+    }
 }
 
 #[test]

--- a/tests/integration/spec.rs
+++ b/tests/integration/spec.rs
@@ -3,7 +3,7 @@ use std::{
     collections::{BTreeMap, HashMap},
 };
 
-use json_with_comments::{from_str, from_str_raw, to_string};
+use json_with_comments::{from_str, from_str_raw, to_string, to_string_pretty};
 
 #[test]
 fn test_deserialize_str() {
@@ -48,11 +48,10 @@ fn test_not_string_map_key() {
     }"#;
     let map: BTreeMap<bool, i32> = from_str(target_bool).unwrap();
     assert_eq!(map, BTreeMap::from([(true, 1), (false, 0)]));
-    // TODO key serialize as str
-    // let jsonc = to_string_pretty(&map, Default::default()).unwrap();
-    // for (tl, jl) in target_bool.lines().zip(jsonc.lines()) {
-    //     assert_eq!(tl.trim(), jl.trim());
-    // }
+    let jsonc = to_string_pretty(&map, Default::default()).unwrap();
+    for (tl, jl) in target_bool.lines().zip(jsonc.lines()) {
+        assert_eq!(tl.trim(), jl.trim());
+    }
 
     let target_number_key = r#"{
         "1": false,

--- a/tests/integration/spec.rs
+++ b/tests/integration/spec.rs
@@ -62,11 +62,10 @@ fn test_not_string_map_key() {
     }"#;
     let map: BTreeMap<u64, bool> = from_str(target_number_key).unwrap();
     assert_eq!(map, BTreeMap::from([(1, false), (2, true), (3, true), (4, false), (5, true)]));
-    // TODO key serialize as str
-    // let jsonc = to_string_pretty(&map, Default::default()).unwrap();
-    // for (tl, jl) in target_number_key.lines().zip(jsonc.lines()) {
-    //     assert_eq!(tl.trim(), jl.trim());
-    // }
+    let jsonc = to_string_pretty(&map, Default::default()).unwrap();
+    for (tl, jl) in target_number_key.lines().zip(jsonc.lines()) {
+        assert_eq!(tl.trim(), jl.trim());
+    }
 }
 
 #[test]


### PR DESCRIPTION
`HashMap::from([1, 2])` should be serialized as `{"1": 2}`, but was `{1: 2}`